### PR TITLE
feat&refator: content 퍼블리싱 및 footer 삭제, sidebar 수정

### DIFF
--- a/src/components/common/MainContent.vue
+++ b/src/components/common/MainContent.vue
@@ -1,0 +1,16 @@
+<template>
+  <section class="content"></section>
+</template>
+<script>
+export default {};
+</script>
+<style lang="scss" scoped>
+.content {
+  position: fixed;
+  margin-left: 20%;
+  margin-top: 0.3rem;
+  min-height: calc(100vh - 115px);
+  width: 78.5%;
+  background: var(--color-white);
+}
+</style>

--- a/src/components/common/MainFotter.vue
+++ b/src/components/common/MainFotter.vue
@@ -1,7 +1,0 @@
-<template lang="">
-  <div>MainFotter PAge</div>
-</template>
-<script>
-export default {};
-</script>
-<style lang=""></style>

--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -51,9 +51,9 @@ li {
   display: flex;
   position: fixed;
   flex-direction: column;
-  width: 260px;
+  width: 15%;
   height: 80%;
-  padding: 0rem 2rem 2rem 2rem;
+  padding: 1rem 2rem 2rem 2rem;
 
   &__menu {
     height: 7rem;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,7 +3,6 @@ import LogIn from '@/views/LoginView.vue';
 import MainView from '@/views/MainView.vue';
 import MainAlaram from '@/components/alarm/MainAlaram.vue';
 import MainCalendar from '@/components/calendar/MainCalendar.vue';
-import MainFotter from '@/components/common/MainFotter.vue';
 import MainHeader from '@/components/common/MainHeader.vue';
 import MainSidebar from '@/components/common/MainSidebar.vue';
 import MainFriend from '@/components/friend/MainFriend.vue';
@@ -30,11 +29,6 @@ const routes = [
     path: '/test2',
     name: 'test',
     component: MainCalendar,
-  },
-  {
-    path: '/test3',
-    name: 'test3',
-    component: MainFotter,
   },
   {
     path: '/test4',

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,17 +1,16 @@
 <template lang="">
-  <div>
+  <div class="body">
     <MainHeader />
     <MainSidebar />
-    <MainFotter />
+    <MainContent />
   </div>
 </template>
 <script>
 import MainHeader from '@/components/common/MainHeader.vue';
 import MainSidebar from '@/components/common/MainSidebar.vue';
-import MainFotter from '@/components/common/MainFotter.vue';
+import MainContent from '@/components/common/MainContent.vue';
 export default {
   name: 'MainView',
-  components: { MainHeader, MainSidebar, MainFotter },
+  components: { MainHeader, MainSidebar, MainContent },
 };
 </script>
-<style lang=""></style>


### PR DESCRIPTION
## content
- 메인화면 content 영역 퍼블리싱

## footer
- 사용하지 않기로 하여 해당 컴포넌트 삭제

## sidebar
- content 퍼블리싱 하면서 발생한 반응형 문제 해결
- width: 260 px -> 15% 변경
- padding-top: 1rem 변경