### PR TITLE
refactor: 프로필 페이지 리팩토링 + 사이드바 CSS 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,23 @@
 <template>
   <div>
-    <router-view></router-view>
+    <router-view :key="$route.fullPath"></router-view>
   </div>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      url: window.location.href,
+    }
+  },
+  mounted() {
+    if (this.url === 'http://localhost:8081/') {
+      this.$router.push('login')
+    }
+  },
+}
+</script>
 
 <style lang="scss">
 :root {

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ export default {
     }
   },
   mounted() {
-    if (this.url === 'http://localhost:8081/') {
+    if (this.url === 'http://localhost:8080/') {
       this.$router.push('login')
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@ export default {
   --color-light-blue: #c3d8ec;
   --color-dark-gray: #585757;
   --color-gray: #969696;
+  --color-semi-gray: #cccccc;
   --color-light-gray: #f2f2f2;
   --color-green: #04ba33;
   --color-light-green: #e5f8eb;

--- a/src/components/account/AccountView.vue
+++ b/src/components/account/AccountView.vue
@@ -82,7 +82,6 @@ export default {
   computed: {},
   watch: {
     $route(to) {
-      console.log(to.path)
       if (to.path === '/signin') {
         this.toggle = false
       } else if (to.path === '/login') {

--- a/src/components/common/MainContent.vue
+++ b/src/components/common/MainContent.vue
@@ -24,6 +24,7 @@ export default {
   width: 78.5%;
   max-width: 1500px;
   background: var(--color-white);
+  overflow-y: hidden;
 
   article {
     background: none;

--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -57,6 +57,7 @@
             :key="i"
             v-for="(friend, i) in friends"
             class="sidebar__friends-item"
+            @click="getFriendProfile(friend.id)"
           >
             <img class="sidebar__friends-item-img" :src="friend.img_url" />
             <span class="sidebar__friends-item-name">{{
@@ -74,11 +75,31 @@ export default {
     return {
       // 임시 데이터. 수정 필요함
       friends: [
-        { username: '이필웅', img_url: require('@/assets/img_flitto.png') },
-        { username: '김소현', img_url: require('@/assets/img_flitto.png') },
-        { username: '김효은', img_url: require('@/assets/img_flitto.png') },
-        { username: '김도경', img_url: require('@/assets/img_flitto.png') },
-        { username: '윤성철', img_url: require('@/assets/img_flitto.png') },
+        {
+          id: 0,
+          username: '이필웅',
+          img_url: require('@/assets/img_flitto.png'),
+        },
+        {
+          id: 1,
+          username: '김소현',
+          img_url: require('@/assets/img_flitto.png'),
+        },
+        {
+          id: 2,
+          username: '김효은',
+          img_url: require('@/assets/img_flitto.png'),
+        },
+        {
+          id: 3,
+          username: '김도경',
+          img_url: require('@/assets/img_flitto.png'),
+        },
+        {
+          id: 4,
+          username: '윤성철',
+          img_url: require('@/assets/img_flitto.png'),
+        },
       ],
       toggle: false,
       isCalendar: true,
@@ -95,6 +116,11 @@ export default {
         this.isCalendar = false
       }
     }
+  },
+  methods: {
+    getFriendProfile(id) {
+      this.$router.push(`/main/profile/${id}`)
+    },
   },
   watch: {},
 }

--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -87,7 +87,6 @@ export default {
     }
   },
   mounted() {
-    console.log('url :', this.$route.path)
     if (this.url.slice(0, 14) !== '/main/calendar') {
       if (this.url.slice(0, 12) !== '/main/friend') {
         this.isOther = true

--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -3,21 +3,24 @@
     <article class="sidebar__menu">
       <div
         :class="{
-          'sidebar__menu-calendar': !isCalendar,
-          'sidebar__menu-calendar-clicked': isCalendar,
+          'sidebar__menu-calendar':
+            !isCalendar || (isCalendar && isOther === true),
+          'sidebar__menu-calendar-clicked': isCalendar && isOther === false,
         }"
         @click=";[$router.push('/main/calendar'), (isCalendar = true)]"
       >
         <i
+          class="sidebar__menu-calendar-icon"
           :class="{
-            'sidebar__menu-calendar-icon': !isCalendar,
-            'sidebar__menu-calendar-clicked-icon': isCalendar,
+            'sidebar__menu-calendar-clicked-icon':
+              isCalendar && isOther === false,
           }"
         />
         <span
+          class="sidebar__menu-calendar-text"
           :class="{
-            'sidebar__menu-calendar-text': !isCalendar,
-            'sidebar__menu-calendar-clicked-text': isCalendar,
+            'sidebar__menu-calendar-clicked-text':
+              isCalendar && isOther === false,
           }"
           >일정</span
         >
@@ -79,13 +82,19 @@ export default {
       ],
       toggle: false,
       isCalendar: true,
+      isOther: false,
       url: this.$route.path,
     }
   },
   mounted() {
     console.log('url :', this.$route.path)
     if (this.url.slice(0, 14) !== '/main/calendar') {
-      this.isCalendar = false
+      if (this.url.slice(0, 12) !== '/main/friend') {
+        this.isOther = true
+      } else {
+        this.isOther = false
+        this.isCalendar = false
+      }
     }
   },
   watch: {},
@@ -217,7 +226,7 @@ li {
         transition: 0.2s ease;
 
         &:hover {
-          background-color: rgba(70, 70, 70, 0.3);
+          background-color: rgba(70, 70, 70, 0.2);
           border-radius: 10px;
         }
 
@@ -245,7 +254,7 @@ li {
 
       &:hover {
         padding: 0.5rem;
-        background-color: var(--color-gray);
+        background-color: rgba(70, 70, 70, 0.2);
       }
 
       &-img {
@@ -257,9 +266,6 @@ li {
 
       &-name {
         background: none;
-        &:hover {
-          background: var(--color-gray);
-        }
       }
     }
   }

--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -108,13 +108,12 @@ export default {
     }
   },
   mounted() {
-    if (this.url.slice(0, 14) !== '/main/calendar') {
-      if (this.url.slice(0, 12) !== '/main/friend') {
-        this.isOther = true
-      } else {
-        this.isOther = false
-        this.isCalendar = false
-      }
+    const url = this.url.slice(6)
+    if (url !== 'calendar' && url !== 'friend') {
+      this.isOther = true
+    } else if (url !== 'calendar' && url === 'friend') {
+      this.isOther = false
+      this.isCalendar = false
     }
   },
   methods: {
@@ -251,7 +250,7 @@ li {
         transition: 0.2s ease;
 
         &:hover {
-          background-color: rgba(70, 70, 70, 0.2);
+          background-color: var(--color-semi-gray);
           border-radius: 10px;
         }
 
@@ -279,7 +278,7 @@ li {
 
       &:hover {
         padding: 0.5rem;
-        background-color: rgba(70, 70, 70, 0.2);
+        background-color: var(--color-semi-gray);
       }
 
       &-img {

--- a/src/components/common/ScheduleCard.vue
+++ b/src/components/common/ScheduleCard.vue
@@ -22,10 +22,17 @@
 export default {
   props: {
     schedules: Object,
-    getParticipant: Function,
   },
   data() {
     return {}
+  },
+  methods: {
+    getParticipant(iterable) {
+      const allParticipant = iterable.reduce((prev, cur) => {
+        return prev + ' ' + cur
+      })
+      return allParticipant
+    },
   },
 }
 </script>

--- a/src/components/common/ScheduleCard.vue
+++ b/src/components/common/ScheduleCard.vue
@@ -1,0 +1,85 @@
+<template>
+  <ul class="schedule">
+    <li class="schedule-card" v-for="(schedule, i) in schedules" :key="i">
+      <div class="schedule-card-container">
+        <div class="schedule-card-image">
+          <i />
+        </div>
+        <div class="schedule-card__content">
+          <p class="schedule-card__content-title">
+            [{{ schedule.council }}] {{ schedule.title }}
+          </p>
+          <p class="schedule-card__content-time">{{ schedule.time }}</p>
+          <p class="schedule-card__content-participant">
+            {{ getParticipant(schedule.participant) }}
+          </p>
+        </div>
+      </div>
+    </li>
+  </ul>
+</template>
+<script>
+export default {
+  props: {
+    schedules: Object,
+    getParticipant: Function,
+  },
+  data() {
+    return {}
+  },
+}
+</script>
+<style lang="scss">
+// 스케쥴 카드 파트
+.schedule-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  background-color: var(--color-light-blue);
+  border-bottom: 1px solid var(--color-gray);
+  margin-bottom: 1px;
+  cursor: pointer;
+
+  &-container {
+    display: flex;
+    flex-direction: row;
+    background: none;
+  }
+  &-image {
+    display: flex;
+    width: 75px;
+    height: 75px;
+    justify-content: center;
+    align-items: center;
+    background: none;
+
+    i {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: url('@/assets/img_flitto.png');
+      background-size: cover;
+    }
+  }
+
+  &__content {
+    margin-left: 1rem;
+    font-size: var(--font-size-h5);
+    background: none;
+
+    &-title {
+      background: none;
+    }
+
+    &-time {
+      background: none;
+      margin-left: 0.5rem;
+    }
+
+    &-participant {
+      background: none;
+      margin-left: 0.5rem;
+    }
+  }
+}
+</style>

--- a/src/components/profile/MainProfile.vue
+++ b/src/components/profile/MainProfile.vue
@@ -68,25 +68,12 @@
         <hr />
       </div>
       <!-- 스케쥴 카드 파트 -->
-      <ul v-if="schedules && isPublic === true" class="schedule">
-        <!-- container 부분을 수정하기 종속관계가 존재하면 클래스명을 유사하게 -->
-        <li class="schedule-card" v-for="(schedule, i) in schedules" :key="i">
-          <div class="schedule-card-container">
-            <div class="schedule-card-image">
-              <i />
-            </div>
-            <div class="schedule-card__content">
-              <p class="schedule-card__content-title">
-                [{{ schedule.council }}] {{ schedule.title }}
-              </p>
-              <p class="schedule-card__content-time">{{ schedule.time }}</p>
-              <p class="schedule-card__content-participant">
-                {{ getParticipant(schedule.participant) }}
-              </p>
-            </div>
-          </div>
-        </li>
-      </ul>
+      <ScheduleCard
+        v-if="schedules && isPublic === true"
+        :schedules="schedules"
+        :getParticipant="this.getParticipant"
+        @click="$router.push('/main/alarm')"
+      />
       <div v-if="schedules.length === 0" class="schedule-empty">
         <i class="schedule-empty-image" />
         <p class="schedule-empty-text">오늘 등록된 일정이 없습니다.</p>
@@ -107,8 +94,9 @@
 
 <script>
 import ProfileModal from '../modal/ProfileModal.vue'
+import ScheduleCard from '../common/ScheduleCard.vue'
 export default {
-  components: { ProfileModal },
+  components: { ProfileModal, ScheduleCard },
   data() {
     return {
       name: '김소현',
@@ -160,13 +148,11 @@ export default {
         week[date.getDay()]
       )
     },
-    // reduce나 다른 메소드
     getParticipant(iterable) {
-      let participant = ''
-      for (let i of iterable) {
-        participant += i + ' '
-      }
-      return participant
+      const allParticipant = iterable.reduce((prev, cur) => {
+        return prev + ' ' + cur
+      })
+      return allParticipant
     },
     toggleInput() {
       this.toggle = !this.toggle
@@ -399,7 +385,6 @@ export default {
             transform: translateX(32px);
           }
 
-          // 슬라이더 바 부분
           &-slider {
             position: absolute;
             cursor: pointer;
@@ -412,7 +397,6 @@ export default {
             transition: 0.4s;
             border-radius: 34px;
 
-            // 선택하는 원형
             &::before {
               position: absolute;
               content: '';
@@ -431,7 +415,6 @@ export default {
     }
   }
 
-  // 스케쥴 안내 부분
   &__body {
     margin: 2rem auto;
     width: 90%;
@@ -456,59 +439,6 @@ export default {
       hr {
         border: 0.5px solid var(--color-black);
         margin: 0.5rem 0 1rem 0;
-      }
-    }
-
-    // 스케쥴 카드 파트
-    .schedule-card {
-      display: flex;
-      flex-direction: column;
-      padding: 1.5rem;
-      background-color: var(--color-light-blue);
-      border-bottom: 1px solid var(--color-gray);
-      margin-bottom: 1px;
-      cursor: pointer;
-
-      &-container {
-        display: flex;
-        flex-direction: row;
-        background: none;
-      }
-      &-image {
-        display: flex;
-        width: 75px;
-        height: 75px;
-        justify-content: center;
-        align-items: center;
-        background: none;
-
-        i {
-          width: 40px;
-          height: 40px;
-          border-radius: 50%;
-          background: url('@/assets/img_flitto.png');
-          background-size: cover;
-        }
-      }
-
-      &__content {
-        margin-left: 1rem;
-        font-size: var(--font-size-h5);
-        background: none;
-
-        &-title {
-          background: none;
-        }
-
-        &-time {
-          background: none;
-          margin-left: 0.5rem;
-        }
-
-        &-participant {
-          background: none;
-          margin-left: 0.5rem;
-        }
       }
     }
 

--- a/src/components/profile/MainProfile.vue
+++ b/src/components/profile/MainProfile.vue
@@ -186,6 +186,7 @@ export default {
   width: 100%;
   height: calc(100vh - 115px);
   background: none;
+  overflow-y: auto;
 
   // 헤더 부분
   &__header {
@@ -467,6 +468,7 @@ export default {
       background-color: var(--color-light-blue);
       border-bottom: 1px solid var(--color-gray);
       margin-bottom: 1px;
+      cursor: pointer;
 
       &-container {
         display: flex;

--- a/src/components/profile/MainProfile.vue
+++ b/src/components/profile/MainProfile.vue
@@ -71,7 +71,6 @@
       <ScheduleCard
         v-if="schedules && isPublic === true"
         :schedules="schedules"
-        :getParticipant="this.getParticipant"
         @click="$router.push('/main/alarm')"
       />
       <div v-if="schedules.length === 0" class="schedule-empty">
@@ -148,12 +147,7 @@ export default {
         week[date.getDay()]
       )
     },
-    getParticipant(iterable) {
-      const allParticipant = iterable.reduce((prev, cur) => {
-        return prev + ' ' + cur
-      })
-      return allParticipant
-    },
+
     toggleInput() {
       this.toggle = !this.toggle
     },

--- a/src/components/profile/MainProfile.vue
+++ b/src/components/profile/MainProfile.vue
@@ -170,7 +170,6 @@ export default {
     },
     toggleInput() {
       this.toggle = !this.toggle
-      console.log(this.toggle)
     },
     openModal() {
       this.modal = true

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,6 +25,7 @@ const routes = [
     name: 'Main',
     component: MainView,
     children: [
+      { path: 'profile', component: MainProfile },
       { path: 'profile/:id', component: MainProfile },
       { path: 'friend', component: MainFriend },
       { path: 'calendar', component: MainCalendar },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,7 +25,7 @@ const routes = [
     name: 'Main',
     component: MainView,
     children: [
-      { path: 'profile', component: MainProfile },
+      { path: 'profile/:id', component: MainProfile },
       { path: 'friend', component: MainFriend },
       { path: 'calendar', component: MainCalendar },
       { path: 'alarm', component: MainAlaram },


### PR DESCRIPTION
* 컨텐츠 영역 및 프로필 오버플로우 추가로 반응성 개선
* 개발 플로우 상 메인 화면(https://localhost:8080/)일 때 자동으로 로그인으로 이동하도록 임시 수정
* 사이드바 메뉴 클릭에서 알람 페이지, 프로필 페이지 등 메뉴와 연관없는 url 클릭 시 메뉴 클릭 css 하이라이팅 되는 부분 개선
* 디버깅용 불필요 구문(console.log()) 삭제
* profile/id의 형태로 Mockdata에 id값 수정 및 라우팅 설정 추가.
* 사이드바 친구 목록에서 친구 프로필 클릭 시 해당 id값으로 라우팅 되도록 설정 변경 + 일부 css 더 자연스럽게 수정
* MainProfile에서 스케쥴 카드 나타내는 부분 컴포넌트화하여 분리 및 해당 스케쥴 카드 참여 인원 나열하는 스크립트 for문에서 reduce로 리팩토링